### PR TITLE
bug: add name_pretty to .repo-metadata.json

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -1,5 +1,6 @@
 {
-  "name": "Google Cloud Java Conformance Tests",
+  "name": "conformance-tests",
+  "name_pretty": "Google Cloud Java Conformance Tests",
   "release_level": "beta",
   "repo": "googleapis/java-conformance-tests",
   "repo_short": "java-conformance-tests",


### PR DESCRIPTION
* `.name` in .repo-metadata.json is treated as the artifact name,
  update the value here to reflect this.
* Add new property `.name_pretty` with old value of `.name`.