### PR TITLE
build: add explicit dependencies for guava and protobuf

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,7 @@
   </parent>
 
   <properties>
+    <guava.version>28.1-android</guava.version>
     <protobuf.version>3.9.1</protobuf.version>
     <junit.version>4.12</junit.version>
     <truth.version>1.0</truth.version>
@@ -22,6 +23,16 @@
   </properties>
 
   <dependencies>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>${guava.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java</artifactId>
+      <version>${protobuf.version}</version>
+    </dependency>
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,7 @@
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
       <version>${guava.version}</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.google.protobuf</groupId>


### PR DESCRIPTION
Dependency checker identified guava and protobuf as used dependencies
that were not explicitly declared in pom.xml. I have added them and
updated the version of guava to be in line with other dependencies, and
remove a diamond.
