### PR TITLE
deps: update dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,11 +15,11 @@
 
   <properties>
     <guava.version>28.1-android</guava.version>
-    <protobuf.version>3.9.1</protobuf.version>
+    <protobuf.version>3.10.0</protobuf.version>
     <junit.version>4.12</junit.version>
     <truth.version>1.0</truth.version>
-    <firestore.version>1.21.0</firestore.version>
-    <bigtable.version>0.74.0</bigtable.version>
+    <firestore.version>1.27.0</firestore.version>
+    <bigtable.version>0.80.0</bigtable.version>
   </properties>
 
   <dependencies>
@@ -39,7 +39,7 @@
       <artifactId>junit</artifactId>
       <version>${junit.version}</version>
       <scope>test</scope>
-    </dependency>
+    </dependency>                         
     <dependency>
       <groupId>com.google.truth</groupId>
       <artifactId>truth</artifactId>


### PR DESCRIPTION
| Package | Update | Change |
|---|---|---|
| com.google.api.grpc:proto-google-cloud-firestore-v1 | minor | `1.21.0` -> `1.27.0` |
| com.google.api.grpc:proto-google-cloud-bigtable-v2 | minor | `0.74.0` -> `0.80.0` |
| com.google.protobuf:protobuf-java | minor | `3.9.1` -> `3.10.0` |

Both of these libraries have to be bumped at the same time otherwise a
version diamond is created for `com.google.api.grpc:proto-google-common-protos`

Supersedes #6, #7 & #12 
