### PR TITLE
chore: update renovate.json to specify empty commitMessagePrefix

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,5 @@
 {
+  "commitMessagePrefix": "",
   "extends": [
     "config:base"
   ],


### PR DESCRIPTION
Updating renovate.json config to set `commitMessagePrefix` to empty
string in an attempt to prevent it from adding `chore()` around `deps`.

https://docs.renovatebot.com/configuration-options/#commitmessageprefix
