### PR TITLE
build: move copyright header processing into maven

### DIFF
--- a/copyright-header.txt
+++ b/copyright-header.txt
@@ -1,15 +1,13 @@
-/*
- * Copyright 2019 Google LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+Copyright 2019 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/generate-conformance-tests.sh
+++ b/generate-conformance-tests.sh
@@ -64,19 +64,6 @@ function main() {
   msg "Generating protos"
   mvn -Pgen-conformance-protos clean verify >> ${LOG_FILE} 2>&1
 
-  msg "Adding copyright header to generated sources"
-  ## java classes generated from protoc do not include the copyright header
-  ## prepend it to the generated files
-  pushd target/generated-sources/protobuf/java/ > /dev/null 2>&1
-  for f in $(find ./ -type f -name '*.java' | sort); do
-    msg "Processing $f"
-    mv ${f} ${f}.tmp
-    cat ${MODULE_DIR}/copyright-header.txt > ${f}
-    cat ${f}.tmp >> ${f}
-    rm ${f}.tmp
-  done
-  popd > /dev/null 2>&1
-
   ## move generated proto class(es) into the main src root
   cpDir src/main/java/ target/generated-sources/protobuf/java/*
 

--- a/pom.xml
+++ b/pom.xml
@@ -100,6 +100,46 @@
             </configuration>
           </plugin>
           <plugin>
+            <groupId>com.mycila</groupId>
+            <artifactId>license-maven-plugin</artifactId>
+            <version>3.0</version>
+            <executions>
+              <execution>
+                <id>license-main</id>
+                <goals>
+                  <goal>format</goal>
+                </goals>
+                <phase>process-sources</phase>
+                <configuration>
+                  <includes>
+                    <include>src/main/java/**</include>
+                    <include>target/generated-sources/**/java/**</include>
+                  </includes>
+                </configuration>
+              </execution>
+              <execution>
+                <id>license-test</id>
+                <goals>
+                  <goal>format</goal>
+                </goals>
+                <phase>process-test-sources</phase>
+                <configuration>
+                  <includes>
+                    <include>src/test/java/**</include>
+                    <include>target/generated-test-sources/**/java/**</include>
+                  </includes>
+                </configuration>
+              </execution>
+            </executions>
+            <configuration>
+              <header>copyright-header.txt</header>
+              <mapping>
+                <java>SLASHSTAR_STYLE</java>
+              </mapping>
+              <useDefaultExcludes>false</useDefaultExcludes>
+            </configuration>
+          </plugin>
+          <plugin>
             <groupId>com.coveo</groupId>
             <artifactId>fmt-maven-plugin</artifactId>
             <version>2.9</version>


### PR DESCRIPTION
With the update to google-cloud-shared-config 0.2.1 maven now runs checkstyle verification automatically during the build. By moving the license header processing into the maven lifecycle we can ensure the headers are in place by the time verification happens.
