### PR TITLE
chore: fix synth excludes

### DIFF
--- a/synth.py
+++ b/synth.py
@@ -19,6 +19,6 @@ import synthtool.languages.java as java
 AUTOSYNTH_MULTIPLE_COMMITS = True
 
 java.common_templates(excludes=[
-    'samples/*'
+    'samples/*',
     'README.md',
 ])


### PR DESCRIPTION
Missing comma. In python, this is allowed to concatenate strings.