### PR TITLE
build: fix maven config errors preventing code generation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,10 @@
     <version>0.8.1</version>
   </parent>
 
+  <properties>
+    <protobuf.version>3.12.2</protobuf.version>
+  </properties>
+
   <dependencyManagement>
     <dependencies>
       <dependency>
@@ -41,6 +45,7 @@
     <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
+      <version>${protobuf.version}</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>
@@ -153,7 +158,7 @@
           <plugin>
             <groupId>com.coveo</groupId>
             <artifactId>fmt-maven-plugin</artifactId>
-            <version>2.10</version>
+            <version>2.9</version>
             <executions>
               <execution>
                 <id>format-main</id>
@@ -175,6 +180,13 @@
                 <directory>target/generated-sources/protobuf/java</directory>
               </additionalSourceDirectories>
             </configuration>
+            <dependencies>
+              <dependency>
+                <groupId>com.google.googlejavaformat</groupId>
+                <artifactId>google-java-format</artifactId>
+                <version>1.7</version>
+              </dependency>
+            </dependencies>
           </plugin>
         </plugins>
       </build>


### PR DESCRIPTION
Define protobuf.version property needed to bind protoc plugin to version
of protobuf in use. java-conformance-tests generates code from protos
via the `org.xolstice.maven.plugins:protobuf-maven-plugin` in conjunction
with the `com.google.protobuf:protoc` bundle. The version used for protoc
selection should be the same as the protobuf-java plugin, and can't be
inherited from a BOM.

Pin fmt-maven-plugin to v2.9 and manually set its version of
google-java-format to 1.7, which is compatible with JDK8.

