### PR TITLE
build: add .github/workflows/generate.yaml action

### DIFF
--- a/.github/workflows/generate.yaml
+++ b/.github/workflows/generate.yaml
@@ -1,0 +1,14 @@
+on: [pull_request]
+name: generate-conformance-tests
+jobs:
+  units:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        java: [ 8, 11 ]
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-java@v1
+      with:
+        java-version: ${{matrix.java}}
+    - run: ./generate-conformance-tests.sh

--- a/.github/workflows/generate.yaml
+++ b/.github/workflows/generate.yaml
@@ -8,6 +8,8 @@ jobs:
         java: [ 8, 11 ]
     steps:
     - uses: actions/checkout@v2
+      with:
+        submodules: true
     - uses: actions/setup-java@v1
       with:
         java-version: ${{matrix.java}}

--- a/generate-conformance-tests.sh
+++ b/generate-conformance-tests.sh
@@ -20,11 +20,24 @@ LOG_FILE_NAME="generate.log"
 LOG_FILE=${MODULE_DIR}/${LOG_FILE_NAME}
 
 function errNotify() {
-    echo "Error while generating conformance tests" >&2;
-    echo "See ${LOG_FILE_NAME} for details" >&2;
+    println "Error while generating conformance tests";
+    if [[ ${CI:-false} == true ]]; then
+      println "Dumping log file to stderr..."
+      println "--- ${LOG_FILE_NAME} -----------------------------------------------"
+      cat ${LOG_FILE_NAME} | sed 's/^/>> /g' >&2;
+      println "----------------------------------------------------------------"
+    else
+      println "See ${LOG_FILE_NAME} for details";
+    fi
     return 1
 }
 trap errNotify ERR
+
+function reportMaven() {
+  if [[ ${CI:-false} == true ]]; then
+    mvn --version >> $1 2>&1
+  fi
+}
 
 function cpDir() {
   mkdir -p $1
@@ -33,6 +46,7 @@ function cpDir() {
 
 function main() {
   rm ${LOG_FILE} 2> /dev/null || true
+  reportMaven "${LOG_FILE}"
 
   local javaBasePackage="com/google/cloud/conformance"
   local firestorePackage="${javaBasePackage}/firestore/v1"


### PR DESCRIPTION
New action to ensure generation of conformance tests continues to work when updates are made to maven config.

generate-conformance-tests.sh has been updated to try to be aware of running in a CI environment, and if detected and an error happens, the log file will be dumped to stderr.