### PR TITLE
build: update generate-conformance-tests.sh to improve debug-ability

### DIFF
--- a/generate-conformance-tests.sh
+++ b/generate-conformance-tests.sh
@@ -76,11 +76,17 @@ function main() {
   cpDir "src/main/resources/${bigtablePackage}/" conformance-tests/bigtable/v2/*.json
 
   msg "Generating protos"
+  set +o errexit
   mvn -Pgen-conformance-protos clean verify >> ${LOG_FILE} 2>&1
+  mvnExitCode=$?
+  set -o errexit
 
   ## move generated proto class(es) into the main src root
   cpDir src/main/java/ target/generated-sources/protobuf/java/*
 
+  if [ $mvnExitCode -ne 0 ]; then
+    exit $mvnExitCode
+  fi
   ## cleanup any generated files that may have not been moved over
   mvn clean >> ${LOG_FILE} 2>&1
 


### PR DESCRIPTION
In the case that generating protos results in a clirr error the script would exit immediately leaving a diff that removes all generated classes. Now, instead of existing immediately capture the return code from generating the protos and validating them and then exit AFTER copying the newly generated protos. This new behavior allows for a fine grained diff.


