### PR TITLE
chore(deps): stop overriding the protobuf version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,6 @@
     <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
-      <version>${protobuf.version}</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>


### PR DESCRIPTION
google-cloud-shared-dependencies already defines the version
