### PR TITLE
deps: update protobuf-java to v3.17.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,10 +14,6 @@
     <version>0.12.0</version>
   </parent>
 
-  <properties>
-    <protobuf.version>3.17.1</protobuf.version>
-  </properties>
-
   <dependencyManagement>
     <dependencies>
       <dependency>
@@ -89,6 +85,16 @@
   <profiles>
     <profile>
       <id>gen-conformance-protos</id>
+      <properties>
+        <protobuf.version>3.17.2</protobuf.version>
+      </properties>
+      <dependencies>
+        <dependency>
+          <groupId>com.google.protobuf</groupId>
+          <artifactId>protobuf-java</artifactId>
+          <version>${protobuf.version}</version>
+        </dependency>
+      </dependencies>
       <build>
         <plugins>
           <plugin>

--- a/src/main/java/com/google/cloud/conformance/firestore/v1/TestDefinition.java
+++ b/src/main/java/com/google/cloud/conformance/firestore/v1/TestDefinition.java
@@ -15371,10 +15371,22 @@ public final class TestDefinition {
     /**
      * <code>int32 offset = 4;</code>
      *
+     * @return Whether the offset field is set.
+     */
+    boolean hasOffset();
+    /**
+     * <code>int32 offset = 4;</code>
+     *
      * @return The offset.
      */
     int getOffset();
 
+    /**
+     * <code>int32 limit = 5;</code>
+     *
+     * @return Whether the limit field is set.
+     */
+    boolean hasLimit();
     /**
      * <code>int32 limit = 5;</code>
      *
@@ -15850,6 +15862,15 @@ public final class TestDefinition {
     /**
      * <code>int32 offset = 4;</code>
      *
+     * @return Whether the offset field is set.
+     */
+    @java.lang.Override
+    public boolean hasOffset() {
+      return clauseCase_ == 4;
+    }
+    /**
+     * <code>int32 offset = 4;</code>
+     *
      * @return The offset.
      */
     @java.lang.Override
@@ -15861,6 +15882,15 @@ public final class TestDefinition {
     }
 
     public static final int LIMIT_FIELD_NUMBER = 5;
+    /**
+     * <code>int32 limit = 5;</code>
+     *
+     * @return Whether the limit field is set.
+     */
+    @java.lang.Override
+    public boolean hasLimit() {
+      return clauseCase_ == 5;
+    }
     /**
      * <code>int32 limit = 5;</code>
      *
@@ -17040,6 +17070,14 @@ public final class TestDefinition {
       /**
        * <code>int32 offset = 4;</code>
        *
+       * @return Whether the offset field is set.
+       */
+      public boolean hasOffset() {
+        return clauseCase_ == 4;
+      }
+      /**
+       * <code>int32 offset = 4;</code>
+       *
        * @return The offset.
        */
       public int getOffset() {
@@ -17074,6 +17112,14 @@ public final class TestDefinition {
         return this;
       }
 
+      /**
+       * <code>int32 limit = 5;</code>
+       *
+       * @return Whether the limit field is set.
+       */
+      public boolean hasLimit() {
+        return clauseCase_ == 5;
+      }
       /**
        * <code>int32 limit = 5;</code>
        *


### PR DESCRIPTION
* Regenerate all protobuf classes
* Explicitly define version of protobuf in gen-conformance-protos profile so that the version of protobuf-java and protoc are in sync. (This also hopefully will again allow renovate-bot to detect and open PRs to update the version of protobuf. renovate-bot detection has dropped with the integration of #328)

