### PR TITLE
chore: remove linkage-monitor from required checks

### DIFF
--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -19,7 +19,6 @@ branchProtectionRules:
   requiredStatusCheckContexts:
     - 'dependencies (8)'
     - 'dependencies (11)'
-    - 'linkage-monitor'
     - 'lint'
     - 'clirr'
     - 'units (8)'


### PR DESCRIPTION
Related to #354
