### PR TITLE
deps: bump conformance-tests to 5c25424bf26916f10275433b72b5b7e8c6e784ce

### DIFF
--- a/src/main/resources/com/google/cloud/conformance/storage/v1/retry_tests.json
+++ b/src/main/resources/com/google/cloud/conformance/storage/v1/retry_tests.json
@@ -23,15 +23,15 @@
         {"name": "storage.buckets.insert",                "resources": []},
         {"name": "storage.buckets.list",                  "resources": ["BUCKET"]},
         {"name": "storage.buckets.lockRetentionPolicy",   "resources": ["BUCKET"]},
-        {"name": "storage.buckets.testIamPermission",     "resources": ["BUCKET"]},
+        {"name": "storage.buckets.testIamPermissions",    "resources": ["BUCKET"]},
         {"name": "storage.default_object_acl.get",        "resources": ["BUCKET"]},
         {"name": "storage.default_object_acl.list",       "resources": ["BUCKET"]},
-        {"name": "storage.hmacKey.delete",                "resources": []},
-        {"name": "storage.hmacKey.get",                   "resources": []},
-        {"name": "storage.hmacKey.list",                  "resources": []},
-        {"name": "storage.notification.delete",           "resources": ["BUCKET", "NOTIFICATION"]},
-        {"name": "storage.notification.get",              "resources": ["BUCKET", "NOTIFICATION"]},
-        {"name": "storage.notification.list",             "resources": ["BUCKET", "NOTIFICATION"]},
+        {"name": "storage.hmacKey.delete",                "resources": ["HMAC_KEY"]},
+        {"name": "storage.hmacKey.get",                   "resources": ["HMAC_KEY"]},
+        {"name": "storage.hmacKey.list",                  "resources": ["HMAC_KEY"]},
+        {"name": "storage.notifications.delete",          "resources": ["BUCKET", "NOTIFICATION"]},
+        {"name": "storage.notifications.get",             "resources": ["BUCKET", "NOTIFICATION"]},
+        {"name": "storage.notifications.list",            "resources": ["BUCKET", "NOTIFICATION"]},
         {"name": "storage.object_acl.get",                "resources": ["BUCKET", "OBJECT"]},
         {"name": "storage.object_acl.list",               "resources": ["BUCKET", "OBJECT"]},
         {"name": "storage.objects.get",                   "resources": ["BUCKET", "OBJECT"]},
@@ -59,7 +59,7 @@
         {"name": "storage.buckets.patch",         "resources": ["BUCKET"]},
         {"name": "storage.buckets.setIamPolicy",  "resources": ["BUCKET"]},
         {"name": "storage.buckets.update",        "resources": ["BUCKET"]},
-        {"name": "storage.hmacKey.update",        "resources": []},
+        {"name": "storage.hmacKey.update",        "resources": ["HMAC_KEY"]},
         {"name": "storage.objects.compose",       "resources": ["BUCKET", "OBJECT"]},
         {"name": "storage.objects.copy",          "resources": ["BUCKET", "OBJECT"]},
         {"name": "storage.objects.delete",        "resources": ["BUCKET", "OBJECT"]},
@@ -76,20 +76,17 @@
       "description": "conditionally_idempotent_no_retries_when_precondition_is_absent",
       "cases": [
         {
-          "instructions": ["return-503", "return-503"]
+          "instructions": ["return-503"]
         },
         {
-          "instructions": ["return-reset-connection", "return-reset-connection"]
-        },
-        {
-          "instructions": ["return-reset-connection", "return-503"]
+          "instructions": ["return-reset-connection"]
         }
       ],
       "methods": [
         {"name": "storage.buckets.patch",         "resources": ["BUCKET"]},
         {"name": "storage.buckets.setIamPolicy",  "resources": ["BUCKET"]},
         {"name": "storage.buckets.update",        "resources": ["BUCKET"]},
-        {"name": "storage.hmacKey.update",        "resources": []},
+        {"name": "storage.hmacKey.update",        "resources": ["HMAC_KEY"]},
         {"name": "storage.objects.compose",       "resources": ["BUCKET", "OBJECT"]},
         {"name": "storage.objects.copy",          "resources": ["BUCKET", "OBJECT"]},
         {"name": "storage.objects.delete",        "resources": ["BUCKET", "OBJECT"]},
@@ -106,23 +103,40 @@
       "description": "non_idempotent",
       "cases": [
         {
-          "instructions": []
+          "instructions": ["return-503"]
+        },
+        {
+          "instructions": ["return-reset-connection"]
         }
       ],
       "methods": [
+        {"name": "storage.bucket_acl.delete",             "resources": ["BUCKET"]},
+        {"name": "storage.bucket_acl.insert",             "resources": ["BUCKET"]},
+        {"name": "storage.bucket_acl.patch",              "resources": ["BUCKET"]},
+        {"name": "storage.bucket_acl.update",             "resources": ["BUCKET"]},
+        {"name": "storage.default_object_acl.delete",     "resources": ["BUCKET"]},
+        {"name": "storage.default_object_acl.insert",     "resources": ["BUCKET"]},
+        {"name": "storage.default_object_acl.patch",      "resources": ["BUCKET"]},
+        {"name": "storage.default_object_acl.update",     "resources": ["BUCKET"]},
+        {"name": "storage.hmacKey.create",                "resources": []},
+        {"name": "storage.notifications.insert",          "resources": ["BUCKET"]},
+        {"name": "storage.object_acl.delete",             "resources": ["BUCKET", "OBJECT"]},
+        {"name": "storage.object_acl.insert",             "resources": ["BUCKET", "OBJECT"]},
+        {"name": "storage.object_acl.patch",              "resources": ["BUCKET", "OBJECT"]},
+        {"name": "storage.object_acl.update",             "resources": ["BUCKET", "OBJECT"]}
       ],
       "preconditionProvided": false,
       "expectSuccess": false
     },
     {
-      "id": 6,
+      "id": 5,
       "description": "non-retryable errors",
       "cases": [
         {
-          "instructions": ["return-400", "return-400"]
+          "instructions": ["return-400"]
         },
         {
-          "instructions": ["return-401", "return-401"]
+          "instructions": ["return-401"]
         }
       ],
       "methods": [
@@ -140,7 +154,7 @@
         {"name": "storage.buckets.lockRetentionPolicy",   "resources": ["BUCKET"]},
         {"name": "storage.buckets.patch",                 "resources": ["BUCKET"]},
         {"name": "storage.buckets.setIamPolicy",          "resources": ["BUCKET"]},
-        {"name": "storage.buckets.testIamPermission",     "resources": ["BUCKET"]},
+        {"name": "storage.buckets.testIamPermissions",    "resources": ["BUCKET"]},
         {"name": "storage.buckets.update",                "resources": ["BUCKET"]},
         {"name": "storage.default_object_acl.delete",     "resources": ["BUCKET"]},
         {"name": "storage.default_object_acl.get",        "resources": ["BUCKET"]},
@@ -149,14 +163,14 @@
         {"name": "storage.default_object_acl.patch",      "resources": ["BUCKET"]},
         {"name": "storage.default_object_acl.update",     "resources": ["BUCKET"]},
         {"name": "storage.hmacKey.create",                "resources": []},
-        {"name": "storage.hmacKey.delete",                "resources": []},
-        {"name": "storage.hmacKey.get",                   "resources": []},
-        {"name": "storage.hmacKey.list",                  "resources": []},
-        {"name": "storage.hmacKey.update",                "resources": []},
-        {"name": "storage.notification.delete",           "resources": ["BUCKET", "NOTIFICATION"]},
-        {"name": "storage.notification.get",              "resources": ["BUCKET", "NOTIFICATION"]},
-        {"name": "storage.notification.insert",           "resources": ["BUCKET", "NOTIFICATION"]},
-        {"name": "storage.notification.list",             "resources": ["BUCKET", "NOTIFICATION"]},
+        {"name": "storage.hmacKey.delete",                "resources": ["HMAC_KEY"]},
+        {"name": "storage.hmacKey.get",                   "resources": ["HMAC_KEY"]},
+        {"name": "storage.hmacKey.list",                  "resources": ["HMAC_KEY"]},
+        {"name": "storage.hmacKey.update",                "resources": ["HMAC_KEY"]},
+        {"name": "storage.notifications.delete",          "resources": ["BUCKET", "NOTIFICATION"]},
+        {"name": "storage.notifications.get",             "resources": ["BUCKET", "NOTIFICATION"]},
+        {"name": "storage.notifications.insert",          "resources": ["BUCKET", "NOTIFICATION"]},
+        {"name": "storage.notifications.list",            "resources": ["BUCKET", "NOTIFICATION"]},
         {"name": "storage.object_acl.delete",             "resources": ["BUCKET", "OBJECT"]},
         {"name": "storage.object_acl.get",                "resources": ["BUCKET", "OBJECT"]},
         {"name": "storage.object_acl.insert",             "resources": ["BUCKET", "OBJECT"]},


### PR DESCRIPTION
https://github.com/googleapis/conformance-tests/commit/5c25424 chore: rename cloud-storage-dpes to cloud-storage-dpe ([#59](https://github.com/googleapis/conformance-tests/pull/59))
https://github.com/googleapis/conformance-tests/commit/32a2fd4 fix: update scenario 5 to only provide a single instruction for the expected failure ([#58](https://github.com/googleapis/conformance-tests/pull/58))
https://github.com/googleapis/conformance-tests/commit/0fe5931 fix(storage): add methods to s4 non idempotent operations ([#56](https://github.com/googleapis/conformance-tests/pull/56))
https://github.com/googleapis/conformance-tests/commit/64c08de fix(storage): add key resource to HMAC methods that require it ([#54](https://github.com/googleapis/conformance-tests/pull/54))
https://github.com/googleapis/conformance-tests/commit/17650a1 fix(storage): fix typo in method names ([#53](https://github.com/googleapis/conformance-tests/pull/53))

Full diff: https://github.com/googleapis/conformance-tests/compare/37ddc58e5c7ebc2847e67e1cba39bdee9e86e260...5c25424bf26916f10275433b72b5b7e8c6e784ce