### PR TITLE
chore: set gcs-sdk-team as storage codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,11 +4,11 @@
 # For syntax help see:
 # https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax
 
-# The @googleapis/cloud-storage-dpe @googleapis/api-bigtable @googleapis/api-firestore @googleapis/firestore-dpe is the default owner for changes in this repo
-*                       @googleapis/yoshi-java @googleapis/cloud-storage-dpe @googleapis/api-bigtable @googleapis/api-firestore @googleapis/firestore-dpe
+# The @googleapis/gcs-sdk-team @googleapis/api-bigtable @googleapis/api-firestore @googleapis/firestore-dpe is the default owner for changes in this repo
+*                       @googleapis/yoshi-java @googleapis/gcs-sdk-team @googleapis/api-bigtable @googleapis/api-firestore @googleapis/firestore-dpe
 
 # for handwritten libraries, keep codeowner_team in .repo-metadata.json as owner
-**/*.java               @googleapis/cloud-storage-dpe @googleapis/api-bigtable @googleapis/api-firestore @googleapis/firestore-dpe
+**/*.java               @googleapis/gcs-sdk-team @googleapis/api-bigtable @googleapis/api-firestore @googleapis/firestore-dpe
 
 
 # The java-samples-reviewers team is the default owner for samples changes

--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -8,5 +8,5 @@
   "distribution_name": "com.google.cloud:google-cloud-conformance-tests",
   "library_type": "OTHER",
   "client_documentation": "https://github.com/googleapis/java-conformance-tests",
-  "codeowner_team": "@googleapis/cloud-storage-dpe @googleapis/api-bigtable @googleapis/api-firestore @googleapis/firestore-dpe"
+  "codeowner_team": "@googleapis/gcs-sdk-team @googleapis/api-bigtable @googleapis/api-firestore @googleapis/firestore-dpe"
 }


### PR DESCRIPTION
Replace outdated cloud-storage-dpe group