### PR TITLE
chore: replace old partner teams with updated names

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,11 +4,11 @@
 # For syntax help see:
 # https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax
 
-# The @googleapis/gcs-team @googleapis/bigtable-team @googleapis/firestore-team @googleapis/firestore-dpe is the default owner for changes in this repo
-*                       @googleapis/cloud-sdk-java-team @googleapis/gcs-team @googleapis/bigtable-team @googleapis/firestore-team @googleapis/firestore-dpe
+# The @googleapis/gcs-team @googleapis/bigtable-team @googleapis/firestore-team is the default owner for changes in this repo
+*                       @googleapis/cloud-sdk-java-team @googleapis/gcs-team @googleapis/bigtable-team @googleapis/firestore-team
 
 # for handwritten libraries, keep codeowner_team in .repo-metadata.json as owner
-**/*.java               @googleapis/gcs-team @googleapis/bigtable-team @googleapis/firestore-team @googleapis/firestore-dpe
+**/*.java               @googleapis/gcs-team @googleapis/bigtable-team @googleapis/firestore-team
 
 
 # The java-samples-reviewers team is the default owner for samples changes

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,11 +4,11 @@
 # For syntax help see:
 # https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax
 
-# The @googleapis/gcs-sdk-team @googleapis/api-bigtable @googleapis/api-firestore @googleapis/firestore-dpe is the default owner for changes in this repo
-*                       @googleapis/cloud-sdk-java-team @googleapis/gcs-sdk-team @googleapis/api-bigtable @googleapis/api-firestore @googleapis/firestore-dpe
+# The @googleapis/gcs-team @googleapis/bigtable-team @googleapis/firestore-team @googleapis/firestore-dpe is the default owner for changes in this repo
+*                       @googleapis/cloud-sdk-java-team @googleapis/gcs-team @googleapis/bigtable-team @googleapis/firestore-team @googleapis/firestore-dpe
 
 # for handwritten libraries, keep codeowner_team in .repo-metadata.json as owner
-**/*.java               @googleapis/gcs-sdk-team @googleapis/api-bigtable @googleapis/api-firestore @googleapis/firestore-dpe
+**/*.java               @googleapis/gcs-team @googleapis/bigtable-team @googleapis/firestore-team @googleapis/firestore-dpe
 
 
 # The java-samples-reviewers team is the default owner for samples changes

--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -37,7 +37,7 @@ permissionRules:
   - team: Googlers
     # Access level required, one of push|pull|admin|maintain|triage
     permission: pull
-  - team: yoshi-java
+  - team: cloud-sdk-java-team
     permission: push
   - team: yoshi-java-admins
     permission: admin

--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -8,5 +8,5 @@
   "distribution_name": "com.google.cloud:google-cloud-conformance-tests",
   "library_type": "OTHER",
   "client_documentation": "https://github.com/googleapis/java-conformance-tests",
-  "codeowner_team": "@googleapis/gcs-sdk-team @googleapis/api-bigtable @googleapis/api-firestore @googleapis/firestore-dpe"
+  "codeowner_team": "@googleapis/gcs-team @googleapis/bigtable-team @googleapis/firestore-team @googleapis/firestore-dpe"
 }

--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -8,5 +8,5 @@
   "distribution_name": "com.google.cloud:google-cloud-conformance-tests",
   "library_type": "OTHER",
   "client_documentation": "https://github.com/googleapis/java-conformance-tests",
-  "codeowner_team": "@googleapis/gcs-team @googleapis/bigtable-team @googleapis/firestore-team @googleapis/firestore-dpe"
+  "codeowner_team": "@googleapis/gcs-team @googleapis/bigtable-team @googleapis/firestore-team"
 }


### PR DESCRIPTION
This PR replaces old Bigtable, Firestore, and Storage teams with their updated names. b/478003109